### PR TITLE
add getUrl plugins

### DIFF
--- a/src/Plugins/FileUrl.php
+++ b/src/Plugins/FileUrl.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace Overtrue\Flysystem\Cos\Plugins;
+
+use League\Flysystem\Plugin\AbstractPlugin;
+
+class FileUrl extends AbstractPlugin
+{
+    public function getMethod()
+    {
+        return 'getUrl';
+    }
+
+    public function handle($path)
+    {
+        return $this->filesystem->getAdapter()->getUrl($path);
+    }
+}


### PR DESCRIPTION
升级新版后，laravel-flysystem-cos 无法调用 getUrl 方法，需要配置 getUrl 的 plugin 才可以用，参考七牛云的扩展包写了一下