### PR TITLE
parse_url 函数返回的 path 部分可能以斜杠开头导致 url 中出现重复斜杠 /

### DIFF
--- a/src/CosAdapter.php
+++ b/src/CosAdapter.php
@@ -127,7 +127,12 @@ class CosAdapter extends AbstractAdapter implements CanOverwriteFiles
         $url = parse_url($objectUrl);
 
         if (!empty($this->config['cdn'])) {
-            return \sprintf('%s/%s?%s', \rtrim($this->config['cdn'], '/'), urldecode($url['path']), $url['query']);
+            return \sprintf(
+                '%s/%s?%s',
+                \rtrim($this->config['cdn'], '/'),
+                \ltrim(urldecode($url['path']), '/'),
+                $url['query']
+            );
         }
 
         return $objectUrl;


### PR DESCRIPTION
```php
return \sprintf('%s/%s?%s', \rtrim($this->config['cdn'], '/'), urldecode($url['path']), $url['query']);
                   ^
          // 这个斜杠可能重复
```

[PHP: sprintf - Manual ](https://www.php.net/manual/zh/function.parse-url.php)

```php
$url = 'http://username:password@hostname/path?arg=value#anchor';

echo parse_url($url, PHP_URL_PATH); // /path
```