### PR TITLE
Fix getMetadata error

### DIFF
--- a/src/CosAdapter.php
+++ b/src/CosAdapter.php
@@ -178,9 +178,9 @@ class CosAdapter implements FilesystemAdapter
 
         return new FileAttributes(
             $path,
-            $meta['Content-Length'][0] ?? null,
+            isset($meta['Content-Length'][0]) ? \strtotime($meta['Content-Length'][0]) : null,
             null,
-            $meta['Last-Modified'][0] ?? null,
+            isset($meta['Last-Modified'][0]) ? \strtotime($meta['Last-Modified'][0]) : null,
             $meta['Content-Type'][0] ?? null,
         );
     }


### PR DESCRIPTION
```bash
League\Flysystem\FileAttributes::__construct(): Argument #4 ($lastModified) must be of type ?int, string given
```