### PR TITLE
Filter out directory when list object

### DIFF
--- a/src/CosAdapter.php
+++ b/src/CosAdapter.php
@@ -435,6 +435,13 @@ class CosAdapter implements FilesystemAdapter
             if (($index = \key($result[$key])) !== 0) {
                 $result[$key] = \is_null($index) ? [] : [$result[$key]];
             }
+
+            //过滤掉目录
+            if ($key === 'Contents') {
+                $result[$key] = \array_filter($result[$key], function ($item) {
+                    return ! \str_ends_with($item['Key'], '/');
+                });
+            }
         }
 
         return $result;


### PR DESCRIPTION
listObject的时候，会把当前目录也列出来。这是在laravel里用其他driver的时候是不会出现的。
导致了用类似spatie/laravel-backup这种库的时候，列出目录文件后再getMime会报错。
而且列出目录确实没有什么必要，可以考虑过滤掉。