### PR TITLE
Update prefix DIRECTORY_SEPARATOR

### DIFF
--- a/src/CosAdapter.php
+++ b/src/CosAdapter.php
@@ -44,7 +44,7 @@ class CosAdapter implements FilesystemAdapter
             $config
         );
 
-        $this->prefixer = new PathPrefixer($config['prefix'] ?? '', DIRECTORY_SEPARATOR);
+        $this->prefixer = new PathPrefixer($config['prefix'] ?? '');
     }
 
     /**


### PR DESCRIPTION
如果在windows环境设置 prefix=test
上传的文件路径会变成 /test\images/1.png
因为windows下 DIRECTORY_SEPARATOR = \

去掉传参 `DIRECTORY_SEPARATOR` 后, 文件路径正常.