### PR TITLE
fix:修复获取临时连接的兼容

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Installation
 
 ```shell
-composer require overtrue/flysystem-cos -vvv
+composer require hepeichun/flysystem-cos -vvv
 ```
 
 ## Usage
@@ -81,19 +81,6 @@ string $flysystem->mimeType('file.md');
 int $flysystem->lastModified('file.md');
 
 ```
-
-## :heart: Sponsor me 
-
-[![Sponsor me](https://github.com/overtrue/overtrue/blob/master/sponsor-me.svg?raw=true)](https://github.com/sponsors/overtrue)
-
-如果你喜欢我的项目并想支持它，[点击这里 :heart:](https://github.com/sponsors/overtrue)
-
-## Project supported by JetBrains
-
-Many thanks to Jetbrains for kindly providing a license for me to work on this and other open-source projects.
-
-[![](https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.svg)](https://www.jetbrains.com/?from=https://github.com/overtrue)
-
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "overtrue/flysystem-cos",
+    "name": "hepeichun/flysystem-cos",
     "description": "Flysystem adapter for the QCloud COS storage.",
     "require": {
         "php": ">=8.0.2",

--- a/src/CosAdapter.php
+++ b/src/CosAdapter.php
@@ -4,7 +4,6 @@ namespace Overtrue\Flysystem\Cos;
 
 use DateTimeInterface;
 use GuzzleHttp\Psr7\Uri;
-use JetBrains\PhpStorm\Pure;
 use League\Flysystem\Config;
 use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\FileAttributes;
@@ -21,7 +20,6 @@ use League\Flysystem\UrlGeneration\TemporaryUrlGenerator;
 use League\Flysystem\Visibility;
 use Overtrue\CosClient\BucketClient;
 use Overtrue\CosClient\Exceptions\ClientException;
-use Overtrue\CosClient\Exceptions\InvalidConfigException;
 use Overtrue\CosClient\ObjectClient;
 use TheNorthMemory\Xml\Transformer;
 
@@ -35,7 +33,6 @@ class CosAdapter implements FilesystemAdapter, TemporaryUrlGenerator
 
     protected array $config;
 
-    #[Pure]
     public function __construct(array $config)
     {
         $this->config = \array_merge(

--- a/src/CosAdapter.php
+++ b/src/CosAdapter.php
@@ -2,6 +2,7 @@
 
 namespace Overtrue\Flysystem\Cos;
 
+use DateTimeInterface;
 use GuzzleHttp\Psr7\Uri;
 use JetBrains\PhpStorm\Pure;
 use League\Flysystem\Config;
@@ -12,16 +13,19 @@ use League\Flysystem\PathPrefixer;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToDeleteDirectory;
 use League\Flysystem\UnableToDeleteFile;
+use League\Flysystem\UnableToGenerateTemporaryUrl;
 use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToWriteFile;
+use League\Flysystem\UrlGeneration\TemporaryUrlGenerator;
 use League\Flysystem\Visibility;
 use Overtrue\CosClient\BucketClient;
 use Overtrue\CosClient\Exceptions\ClientException;
+use Overtrue\CosClient\Exceptions\InvalidConfigException;
 use Overtrue\CosClient\ObjectClient;
 use TheNorthMemory\Xml\Transformer;
 
-class CosAdapter implements FilesystemAdapter
+class CosAdapter implements FilesystemAdapter, TemporaryUrlGenerator
 {
     protected ?ObjectClient $objectClient;
 
@@ -337,18 +341,17 @@ class CosAdapter implements FilesystemAdapter
         return $this->config['signed_url'] ? $this->getSignedUrl($path) : $this->getObjectClient()->getObjectUrl($prefixedPath);
     }
 
-    /**
-     * For laravel FilesystemAdapter.
-     *
-     * @throws \Overtrue\CosClient\Exceptions\InvalidConfigException
-     */
-    public function getTemporaryUrl($path, int|string|\DateTimeInterface $expiration): string
+    public function temporaryUrl(string $path, DateTimeInterface $expiresAt, Config $config): string
     {
-        if ($expiration instanceof \DateTimeInterface) {
-            $expiration = $expiration->getTimestamp();
+        if ($expiresAt instanceof \DateTimeInterface) {
+            $expiration = $expiresAt->getTimestamp();
         }
 
-        return $this->getSignedUrl($path, $expiration);
+        try {
+            return $this->getSignedUrl($path, $expiration);
+        } catch (\Throwable $exception) {
+            throw UnableToGenerateTemporaryUrl::dueToError($path, $exception);
+        }
     }
 
     /**


### PR DESCRIPTION
```php
# vendor/league/flysystem/src/Filesystem.php
public function temporaryUrl(string $path, DateTimeInterface $expiresAt, array $config = []): string
    {
        $generator = $this->temporaryUrlGenerator ?? $this->adapter;

        if ($generator instanceof TemporaryUrlGenerator) {
            return $generator->temporaryUrl(
                $this->pathNormalizer->normalizePath($path),
                $expiresAt,
                $this->config->extend($config)
            );
        }

        throw UnableToGenerateTemporaryUrl::noGeneratorConfigured($path);
    }
```
这里的`$generator instanceof TemporaryUrlGenerator`会检查