### PR TITLE
fix:修复获取临时连接的兼容

### DIFF
--- a/src/CosAdapter.php
+++ b/src/CosAdapter.php
@@ -2,6 +2,7 @@
 
 namespace Overtrue\Flysystem\Cos;
 
+use DateTimeInterface;
 use GuzzleHttp\Psr7\Uri;
 use JetBrains\PhpStorm\Pure;
 use League\Flysystem\Config;
@@ -12,16 +13,19 @@ use League\Flysystem\PathPrefixer;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToDeleteDirectory;
 use League\Flysystem\UnableToDeleteFile;
+use League\Flysystem\UnableToGenerateTemporaryUrl;
 use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToWriteFile;
+use League\Flysystem\UrlGeneration\TemporaryUrlGenerator;
 use League\Flysystem\Visibility;
 use Overtrue\CosClient\BucketClient;
 use Overtrue\CosClient\Exceptions\ClientException;
+use Overtrue\CosClient\Exceptions\InvalidConfigException;
 use Overtrue\CosClient\ObjectClient;
 use TheNorthMemory\Xml\Transformer;
 
-class CosAdapter implements FilesystemAdapter
+class CosAdapter implements FilesystemAdapter, TemporaryUrlGenerator
 {
     protected ?ObjectClient $objectClient;
 
@@ -337,18 +341,17 @@ class CosAdapter implements FilesystemAdapter
         return $this->config['signed_url'] ? $this->getSignedUrl($path) : $this->getObjectClient()->getObjectUrl($prefixedPath);
     }
 
-    /**
-     * For laravel FilesystemAdapter.
-     *
-     * @throws \Overtrue\CosClient\Exceptions\InvalidConfigException
-     */
-    public function getTemporaryUrl($path, int|string|\DateTimeInterface $expiration): string
+    public function temporaryUrl(string $path, DateTimeInterface $expiresAt, Config $config): string
     {
-        if ($expiration instanceof \DateTimeInterface) {
-            $expiration = $expiration->getTimestamp();
+        if ($expiresAt instanceof \DateTimeInterface) {
+            $expiration = $expiresAt->getTimestamp();
         }
 
-        return $this->getSignedUrl($path, $expiration);
+        try {
+            return $this->getSignedUrl($path, $expiration);
+        } catch (\Throwable $exception) {
+            throw UnableToGenerateTemporaryUrl::dueToError($path, $exception);
+        }
     }
 
     /**


### PR DESCRIPTION
# vendor/league/flysystem/src/Filesystem.php
public function temporaryUrl(string $path, DateTimeInterface $expiresAt, array $config = []): string
    {
        $generator = $this->temporaryUrlGenerator ?? $this->adapter;

        if ($generator instanceof TemporaryUrlGenerator) {
            return $generator->temporaryUrl(
                $this->pathNormalizer->normalizePath($path),
                $expiresAt,
                $this->config->extend($config)
            );
        }

        throw UnableToGenerateTemporaryUrl::noGeneratorConfigured($path);
    }
这里的$generator instanceof TemporaryUrlGenerator会检查